### PR TITLE
Implemented sudo-wrapper tool

### DIFF
--- a/NexPay/README.md
+++ b/NexPay/README.md
@@ -1,0 +1,76 @@
+# Sudo Wrapper
+
+The `sudo_wrapper` script enhances the security and convenience of using `sudo` on macOS by integrating Touch ID and password storage in the Keychain. This tool attempts to use the password from the Keychain, falls back to the passkey authentication with TouchID and if it is not successful to regular `sudo` prompt.
+
+## Features
+
+- **Touch ID Integration**: Securely authenticate `sudo` commands using your Mac's Touch ID.
+- **Keychain Integration**: Store and retrieve `sudo` passwords from the macOS Keychain for seamless authentication.
+- **Fallback Mechanism**: Automatically fall back to the standard `sudo` prompt if the Keychain password is not found or authentication fails.
+- **Enhanced Security**: Reduce the need to frequently enter your password, minimizing the risk of password exposure.
+- **Improved Workflow**: Streamline your development workflow with fast and secure `sudo` authentication.
+
+## Advantages
+
+### Enhanced Security
+
+By leveraging Touch ID and the Keychain, the `sudo_wrapper` script significantly improves security for developers:
+- **Touch ID**: Uses biometric authentication, which is more secure than passwords.
+- **Keychain**: Ensures that passwords are stored securely and only accessible by authorized applications.
+
+### Improved Developer Workflow
+
+The `sudo_wrapper` script simplifies and speeds up the process of using `sudo`:
+- **Convenience**: No need to type your password every time you run a `sudo` command.
+- **Efficiency**: Fast and seamless authentication using Touch ID.
+- **Focus**: Allows you to concentrate on development tasks without frequent interruptions for password entry.
+
+## Installation
+
+### Prerequisites
+
+- macOS with Touch ID.
+- Xcode Command Line Tools installed.
+
+### Steps
+
+1. **Run the Installation Script**:
+    ```sh
+    chmod +x install_sudo_wrapper.sh
+    ./install_sudo_wrapper.sh
+    ```
+
+2. **Open a new terminal or source your shell configuration** to apply the changes:
+    ```sh
+    source ~/.bashrc # for bash
+    source ~/.zshrc  # for zsh
+    ```
+
+## Uninstallation
+
+1. **Run the Uninstallation Script**:
+    ```sh
+    chmod +x uninstall_sudo_wrapper.sh
+    ./uninstall_sudo_wrapper.sh
+    ```
+
+2. **Open a new terminal or source your shell configuration** to apply the changes:
+    ```sh
+    source ~/.bashrc # for bash
+    source ~/.zshrc  # for zsh
+    ```
+
+## Usage
+
+After installation, you can use `sudo` as usual, and the wrapper script will handle authentication using Touch ID or the password from the Keychain.
+
+Example:
+```sh
+sudo ls /var/root
+```
+    
+The script will attempt to retrieve the password from the Keychain and use it with sudo. If the password is not found, it will fall back to the passkey authentication with TouchID and if that will not be successful as well to regular sudo prompt.
+
+## Conclusion
+
+The sudo_wrapper script is a valuable tool for developers looking to enhance their workflow's security and efficiency. By integrating Touch ID and the Keychain, this tool provides a seamless and secure way to handle sudo authentication, allowing you to focus more on development tasks and less on repetitive password entry.

--- a/NexPay/install_sudo_wrapper.sh
+++ b/NexPay/install_sudo_wrapper.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Create the sudo wrapper script
+cat << 'EOF' > /usr/local/bin/sudo_wrapper.sh
+#!/bin/bash
+
+# Define the command to be executed with sudo
+COMMAND="$@"
+
+# Try to retrieve the passkey from the keychain
+PASSWORD=$(security find-generic-password -a "$USER" -s "sudo_password" -w 2>/dev/null)
+
+if [ $? -eq 0 ]; then
+    # Passkey found, try to use it with sudo
+    echo "$PASSWORD" | sudo -S $COMMAND
+    # Check if sudo succeeded
+    if [ $? -eq 0 ]; then
+        exit 0
+    fi
+fi
+
+# If passkey not found or sudo failed, fallback to regular sudo prompt (which now includes Touch ID)
+sudo $COMMAND
+EOF
+
+# Make the script executable
+chmod +x /usr/local/bin/sudo_wrapper.sh
+
+# Add the alias to the shell configuration
+SHELL_CONFIG="$HOME/.bashrc"
+if [ -n "$ZSH_VERSION" ]; then
+  SHELL_CONFIG="$HOME/.zshrc"
+fi
+
+# Ensure the alias isn't added multiple times
+grep -qxF 'alias sudo="/usr/local/bin/sudo_wrapper.sh"' "$SHELL_CONFIG" || echo 'alias sudo="/usr/local/bin/sudo_wrapper.sh"' >> "$SHELL_CONFIG"
+
+# Source the shell configuration
+source "$SHELL_CONFIG"
+
+# Add the sudo password to the keychain
+echo "Adding sudo password to the keychain..."
+security add-generic-password -a "$USER" -s "sudo_password" -w
+
+# Modify the sudoers file to include Touch ID
+echo "Modifying the sudoers file to include Touch ID..."
+sudo sed -i '' '1 i\
+auth       sufficient     pam_tid.so\
+' /etc/pam.d/sudo
+
+echo "Installation complete. Please open a new terminal or source your shell configuration to start using the sudo wrapper."

--- a/NexPay/uninstall_sudo_wrapper.sh
+++ b/NexPay/uninstall_sudo_wrapper.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Remove the alias from the shell configuration
+SHELL_CONFIG="$HOME/.bashrc"
+if [ -n "$ZSH_VERSION" ]; then
+  SHELL_CONFIG="$HOME/.zshrc"
+fi
+
+# Remove the alias line
+sed -i '' '/alias sudo="\/usr\/local\/bin\/sudo_wrapper.sh"/d' "$SHELL_CONFIG"
+
+# Remove the script
+rm -f /usr/local/bin/sudo_wrapper.sh
+
+# Remove the keychain item
+security delete-generic-password -a "$USER" -s "sudo_password"
+
+# Restore the sudoers file to its original state (remove the pam_tid line)
+sudo sed -i '' '/auth       sufficient     pam_tid.so/d' /etc/pam.d/sudo
+
+# Source the shell configuration
+source "$SHELL_CONFIG"
+
+echo "Uninstallation complete. Please open a new terminal or source your shell configuration to stop using the sudo wrapper."


### PR DESCRIPTION
We implemented our hackathon solution called sudo-wrapper. The meaning of the tool is to allow a developer to use TouchID and keychain password to authenticate when using the "sudo" command. It is a common annoying step in software development to authorize sudo, and we thought it might be made more transparent and secure by integrating Apple's passkey into the process.

More info can be found in the README.md file.